### PR TITLE
Chore: Fix enabled state condition

### DIFF
--- a/client/ayon_clockify/addon.py
+++ b/client/ayon_clockify/addon.py
@@ -19,7 +19,7 @@ class ClockifyAddon(AYONAddon, ITrayAddon, IPluginPaths):
             clockify_settings = studio_settings[self.name]
             workspace_name = clockify_settings["workspace_name"]
 
-        if enabled and workspace_name:
+        if enabled and not workspace_name:
             self.log.warning("Clockify Workspace is not set in settings.")
             enabled = False
         self.enabled = enabled


### PR DESCRIPTION
## Changelog Description
Addon is enabled when workspace is filled.

## Additional information
The condition to turn off the addon was reversed. I think we should re-factor most of the code to not turn off the addon, but report the issue all the time, but that's different task.

## Testing notes:
1. Clockify integration works with filled workspace.
